### PR TITLE
Oauth2 소셜로그인 로직 수정

### DIFF
--- a/service/src/main/java/com/its/service/config/SwaggerConfig.java
+++ b/service/src/main/java/com/its/service/config/SwaggerConfig.java
@@ -69,15 +69,8 @@ public class SwaggerConfig {
                 .summary(socialTitle)
                 .security(List.of()) // 인증 비활성화
                 .description(String.format("[%s](%s/oauth2/authorization/%s)", socialTitle, backendBaseURL, socialId))
-                .responses(new ApiResponses()
-                        .addApiResponse("302", new ApiResponse()
-                                .content(new Content().addMediaType("application/json",
-                                        new MediaType().schema(new Schema<Map<String, String>>().type("object")
-                                                .example(Map.of(
-                                                        "Set-Cookie", "accessToken=eyJhbGciOiJIUzI1NiJ9.eyJjYXRlZ29yeSI6ImFjY2VzcyIsImVtYWlsIjoiaHdhbmdiYmFuZzlAZ21haWwuY29tIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3MjQ4NTE5MDAsImV4cCI6MjMyOTY1MTkwMH0.64R2DbeY04GMIXllq-9iHOES3_QH4-fCVHVYlor1xrc; Max-Age=3600; Path=/; Domain=localhost; HttpOnly=false; Secure=false, refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJjYXRlZ29yeSI6InJlZnJlc2giLCJlbWFpbCI6Imh3YW5nYmJhbmc5QGdtYWlsLmNvbSIsImlhdCI6MTcyNDg1MTkwMCwiZXhwIjo5NTAwODUxOTAwfQ.0KCs32480Eiyr5XSsirM0O_nGecYdbcgYzpKG7eRpVc; Max-Age=3600; Path=/; Domain=localhost; HttpOnly=false; Secure=false"))
-                                        ))))
-                )
         );
+
     }
     private Info apiInfo() {
         return new Info()

--- a/service/src/main/java/com/its/service/domain/auth/security/filter/JWTFilter.java
+++ b/service/src/main/java/com/its/service/domain/auth/security/filter/JWTFilter.java
@@ -46,7 +46,7 @@ public class JWTFilter extends OncePerRequestFilter {
             if (!jwtUtil.isExpired(accessToken)) {
 
                 User user = tokenService.getUserByAccessToken(accessToken);
-                log.info("[AUTH_INFO] 사용자 인가: ID:{} 이름:{}", user.getUser_id(), user.getName());
+                log.info("[AUTH_INFO] 사용자 인가: ID:{} 이름:{}", user.getUserId(), user.getName());
                 OAuth2UserDTO oauth2UserDTO = OAuth2UserDTO.from(user);
                 CustomOAuth2User customOAuth2User = new CustomOAuth2User(oauth2UserDTO);
                 Authentication authentication = new UsernamePasswordAuthenticationToken(

--- a/service/src/main/java/com/its/service/domain/auth/security/oauth2/dto/OAuth2UserDTO.java
+++ b/service/src/main/java/com/its/service/domain/auth/security/oauth2/dto/OAuth2UserDTO.java
@@ -1,31 +1,26 @@
 package com.its.service.domain.auth.security.oauth2.dto;
 
+import com.its.service.domain.auth.security.util.SocialType;
 import com.its.service.domain.user.entity.User;
 import com.its.service.domain.user.entity.User.UserRole;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class OAuth2UserDTO {
     private final Long userId;
     private final String name;
+    private final SocialType registrationType;
     private final String email;
     private final String profileImage;
     private final UserRole role;
 
-    @Builder
-    public OAuth2UserDTO(Long userId, String name, String email, String profileImage, UserRole role) {
-        this.userId = userId;
-        this.name = name;
-        this.email = email;
-        this.profileImage = profileImage;
-        this.role = role;
-    }
-
     public static OAuth2UserDTO from(User user) {
         return OAuth2UserDTO.builder()
-                .userId(user.getUser_id())
+                .userId(user.getUserId())
                 .name(user.getName())
+                .registrationType(user.getRegistrationType())
                 .email(user.getEmail())
                 .profileImage(user.getProfileImage())
                 .role(user.getUserRole())

--- a/service/src/main/java/com/its/service/domain/auth/security/oauth2/dto/oauth2/CustomOAuth2User.java
+++ b/service/src/main/java/com/its/service/domain/auth/security/oauth2/dto/oauth2/CustomOAuth2User.java
@@ -1,5 +1,6 @@
 package com.its.service.domain.auth.security.oauth2.dto.oauth2;
 
+import com.its.service.domain.auth.security.util.SocialType;
 import com.its.service.domain.user.entity.User.UserRole;
 import com.its.service.domain.auth.security.oauth2.dto.OAuth2UserDTO;
 import org.springframework.security.core.GrantedAuthority;
@@ -36,16 +37,9 @@ public class CustomOAuth2User implements OAuth2User {
     public String getName() {
         return oAuth2UserDTO.getName();
     }
-    public String getEmail() {
-        return oAuth2UserDTO.getEmail();
-    }
-    public Long getUserId() {
-        return oAuth2UserDTO.getUserId();
-    }
-    public String getProfileImage() {
-        return oAuth2UserDTO.getProfileImage();
-    }
-    public UserRole getRole() {
-        return oAuth2UserDTO.getRole();
-    }
+    public SocialType getRegistrationType() {return oAuth2UserDTO.getRegistrationType();}
+    public String getEmail() {return oAuth2UserDTO.getEmail();}
+    public Long getUserId() {return oAuth2UserDTO.getUserId();}
+    public String getProfileImage() {return oAuth2UserDTO.getProfileImage();}
+    public UserRole getRole() {return oAuth2UserDTO.getRole();}
 }

--- a/service/src/main/java/com/its/service/domain/auth/security/oauth2/handler/CustomSuccessHandler.java
+++ b/service/src/main/java/com/its/service/domain/auth/security/oauth2/handler/CustomSuccessHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.its.service.common.response.factory.ResponseFactory;
 import com.its.service.domain.auth.dto.response.LoginResponse;
 import com.its.service.domain.auth.mapper.AuthMapper;
+import com.its.service.domain.auth.security.util.SocialType;
 import com.its.service.domain.auth.service.TokenService;
 import com.its.service.domain.auth.security.oauth2.dto.oauth2.CustomOAuth2User;
 import jakarta.servlet.ServletException;
@@ -24,21 +25,20 @@ import java.io.IOException;
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final TokenService tokenService;
     private final AuthMapper authMapper;
+    private final ObjectMapper objectMapper;
 
-    @Value("${env.base-url}")
-    private String backendBaseURL;
-    private ObjectMapper objectMapper;
+    @Value("${env.base-url}") private String backendBaseURL;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         CustomOAuth2User customOauth2User = (CustomOAuth2User) authentication.getPrincipal();
         String email = customOauth2User.getEmail();
         String role = customOauth2User.getRole().toString();
-
+        SocialType registrationType = customOauth2User.getRegistrationType();
 
         // jwt 생성
-        String accessToken = tokenService.createAccessToken(email, role);
-        String refreshToken = tokenService.createRefreshToken(email);
+        String accessToken = tokenService.createAccessToken(registrationType, email, role);
+        String refreshToken = tokenService.createRefreshToken(registrationType, email);
 
         LoginResponse loginResponse = authMapper.toLoginResponse(accessToken, refreshToken);
         var result = ResponseFactory.success(loginResponse);

--- a/service/src/main/java/com/its/service/domain/auth/security/util/JWTUtil.java
+++ b/service/src/main/java/com/its/service/domain/auth/security/util/JWTUtil.java
@@ -19,6 +19,7 @@ import java.util.Date;
 @Component
 public class JWTUtil {
     private final SecretKey secretKey;
+    private static final String CLAIM_KEY_REGISTRATION_TYPE = "registrationType";
     private static final String CLAIM_KEY_EMAIL = "email";
     private static final String CLAIM_KEY_ROLE = "role";
     private static final String CLAIM_KEY_CATEGORY = "category";
@@ -47,9 +48,11 @@ public class JWTUtil {
     public String getRole(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get(CLAIM_KEY_ROLE, String.class);
     }
-
     public String getCategory(String token){
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get(CLAIM_KEY_CATEGORY, String.class);
+    }
+    public String getRegistrationType(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get(CLAIM_KEY_REGISTRATION_TYPE, String.class);
     }
     public String getEmail(String token){
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get(CLAIM_KEY_EMAIL, String.class);
@@ -58,9 +61,10 @@ public class JWTUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createAccessJwt(String category, String email, String role, Long expiredMs) {
+    public String createAccessJwt(String category, SocialType registrationType, String email, String role, Long expiredMs) {
         return Jwts.builder()
                 .claim(CLAIM_KEY_CATEGORY, category)
+                .claim(CLAIM_KEY_REGISTRATION_TYPE, registrationType)
                 .claim(CLAIM_KEY_EMAIL, email)
                 .claim(CLAIM_KEY_ROLE, role)
                 .issuedAt(new Date(System.currentTimeMillis()))
@@ -68,9 +72,11 @@ public class JWTUtil {
                 .signWith(secretKey)
                 .compact();
     }
-    public String createRefreshJwt(String category, String email, Long expiredMs) {
+
+    public String createRefreshJwt(String category, SocialType registrationType, String email, Long expiredMs) {
         return Jwts.builder()
                 .claim(CLAIM_KEY_CATEGORY, category)
+                .claim(CLAIM_KEY_REGISTRATION_TYPE, registrationType)
                 .claim(CLAIM_KEY_EMAIL, email)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))

--- a/service/src/main/java/com/its/service/domain/auth/service/AuthService.java
+++ b/service/src/main/java/com/its/service/domain/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import com.its.service.common.error.code.AuthErrorCode;
 import com.its.service.common.error.exception.CustomException;
 import com.its.service.domain.auth.dto.response.RefreshResponse;
 import com.its.service.domain.auth.security.util.JWTUtil;
+import com.its.service.domain.auth.security.util.SocialType;
 import com.its.service.domain.user.entity.User;
 
 import com.its.service.domain.user.repository.UserRepository;
@@ -32,8 +33,9 @@ public class AuthService {
         User user = tokenService.getUserByRefreshToken(refreshToken);
         String email = user.getEmail();
         String role = user.getUserRole().toString();
+        SocialType registrationType = user.getRegistrationType();
 
-        String newAccessToken = tokenService.createAccessToken(email, role);
+        String newAccessToken = tokenService.createAccessToken(registrationType, email, role);
         return RefreshResponse.builder().accessToken(newAccessToken).build();
     }
 

--- a/service/src/main/java/com/its/service/domain/auth/service/TokenService.java
+++ b/service/src/main/java/com/its/service/domain/auth/service/TokenService.java
@@ -2,6 +2,7 @@ package com.its.service.domain.auth.service;
 
 import com.its.service.common.error.exception.CustomException;
 import com.its.service.common.error.code.AuthErrorCode;
+import com.its.service.domain.auth.security.util.SocialType;
 import com.its.service.domain.user.entity.User;
 
 import com.its.service.domain.auth.security.util.JWTUtil;
@@ -31,24 +32,26 @@ public class TokenService {
     private String JWT_REFRESH_CATEGORY;
 
 
-    public String createAccessToken(String email, String role) {
-        return jwtUtil.createAccessJwt(JWT_ACCESS_CATEGORY, email, role, accessTokenExpiration * 1000); // 밀리초 -> 초
+    public String createAccessToken(SocialType registrationType, String email, String role) {
+        return jwtUtil.createAccessJwt(JWT_ACCESS_CATEGORY, registrationType, email, role, accessTokenExpiration * 1000); // 밀리초 -> 초
     }
 
-    public String createRefreshToken(String email) {
-        return jwtUtil.createRefreshJwt(JWT_REFRESH_CATEGORY, email, refreshTokenExpiration * 1000); // 밀리초 -> 초
+    public String createRefreshToken(SocialType registrationType, String email) {
+        return jwtUtil.createRefreshJwt(JWT_REFRESH_CATEGORY, registrationType, email, refreshTokenExpiration * 1000); // 밀리초 -> 초
     }
 
     public User getUserByAccessToken(String accessToken) {
         String email = jwtUtil.getEmail(accessToken);
-        return userRepository.findByEmail(email).orElseThrow(() -> {
+        SocialType registrationType = SocialType.from(jwtUtil.getRegistrationType(accessToken));
+        return userRepository.findByEmailAndRegistrationType(email,registrationType).orElseThrow(() -> {
             log.error("[AUTH_ERROR] 유효한 약관 동의 토큰에서 추출된 사용자 email: {}에 해당하는 사용자가 존재하지 않음", email);
             return new CustomException(AuthErrorCode.USER_NOT_EXIST);
         });
     }
     public User getUserByRefreshToken(String refreshToken) {
         String email = jwtUtil.getEmail(refreshToken);
-        return userRepository.findByEmail(email).orElseThrow(() -> {
+        SocialType registrationType = SocialType.from(jwtUtil.getRegistrationType(refreshToken));
+        return userRepository.findByEmailAndRegistrationType(email,registrationType).orElseThrow(() -> {
             log.error("[AUTH_ERROR] 유효한 약관 동의 토큰에서 추출된 사용자 email: {}에 해당하는 사용자가 존재하지 않음", email);
             return new CustomException(AuthErrorCode.USER_NOT_EXIST);
         });

--- a/service/src/main/java/com/its/service/domain/user/entity/User.java
+++ b/service/src/main/java/com/its/service/domain/user/entity/User.java
@@ -1,23 +1,27 @@
 package com.its.service.domain.user.entity;
 
+import com.its.service.domain.auth.security.util.SocialType;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter @Setter
 @Entity
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "user")
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
-    private Long user_id;
+    private Long userId;
 
-    @Column(name="email", unique = true)
-    private String email; //loginId
+    @Enumerated(EnumType.STRING)
+    @Column(name = "registration_type", columnDefinition = "ENUM('KAKAO', 'NAVER', 'GOOGLE', 'APPLE')", nullable = false)
+    private SocialType registrationType;
+
+    @Column(name="email")
+    private String email;
 
     @Column(name="name")
     private String name; // 이름
@@ -29,14 +33,6 @@ public class User {
     @Column(columnDefinition = "ENUM('USER', 'ADMIN') NOT NULL DEFAULT 'USER'")
     private UserRole userRole; // 기본값 USER
 
-    @Builder
-    public User(Long userId, String email, String name, String profileImage, UserRole userRole) {
-        this.user_id = userId;
-        this.email = email;
-        this.name = name;
-        this.profileImage = profileImage;
-        this.userRole = userRole;
-    }
 
     public enum UserRole {
         USER, ADMIN

--- a/service/src/main/java/com/its/service/domain/user/repository/UserRepository.java
+++ b/service/src/main/java/com/its/service/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.its.service.domain.user.repository;
 
+import com.its.service.domain.auth.security.util.SocialType;
 import com.its.service.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +8,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    Optional<User> findByEmailAndRegistrationType(String email, SocialType registrationType);
 }

--- a/service/src/main/java/com/its/service/domain/user/service/UserQueryService.java
+++ b/service/src/main/java/com/its/service/domain/user/service/UserQueryService.java
@@ -18,7 +18,7 @@ public class UserQueryService {
                 () -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
         return ProfileResponse.builder()
-                .userId(user.getUser_id())
+                .userId(user.getUserId())
                 .name(user.getName())
                 .profileImage(user.getProfileImage())
                 .email(user.getEmail())

--- a/service/src/main/resources/db/migration/V001__init.sql
+++ b/service/src/main/resources/db/migration/V001__init.sql
@@ -25,15 +25,13 @@ CREATE TABLE `its-db`.subject
 CREATE TABLE `its-db`.user
 (
     user_id       BIGINT AUTO_INCREMENT                 NOT NULL,
+    registration_type ENUM ('KAKAO', 'NAVER', 'GOOGLE', 'APPLE') NOT NULL,
     email         VARCHAR(255) NULL,
     name          VARCHAR(255) NULL,
     profile_image VARCHAR(255) NULL,
     user_role     ENUM ('USER', 'ADMIN') DEFAULT 'USER' NOT NULL,
     CONSTRAINT pk_user PRIMARY KEY (user_id)
 );
-
-ALTER TABLE `its-db`.user
-    ADD CONSTRAINT uc_user_email UNIQUE (email);
 
 ALTER TABLE `its-db`.minor
     ADD CONSTRAINT FK_MINOR_ON_MAJOR FOREIGN KEY (major_id) REFERENCES `its-db`.major (major_id);


### PR DESCRIPTION
## 주요 변경사항 


### 데이터베이스 스키마 변경 
- email  유니크 제약 조건해제 
- domain이 'KAKAO', 'NAVER', 'GOOGLE', 'APPLE' 인 registrationType 에트리뷰트 추가 

### 로직 변경사항 
- email 과 registrationType 을 KEY 로 사용자 조회 및 등록 
- jwt 토큰 구조 변경 ( CLAIM_KEY_REGISTRATION_TYPE 추가 )