### PR TITLE
Update Swagger API version to 0.1.2 for new API additions 

### DIFF
--- a/service/src/main/java/com/its/service/common/error/code/FavoriteErrorCode.java
+++ b/service/src/main/java/com/its/service/common/error/code/FavoriteErrorCode.java
@@ -1,0 +1,16 @@
+package com.its.service.common.error.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FavoriteErrorCode implements ErrorCode{
+    FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "FAVORITE-001", "해당 즐겨찾기는 존재하지 않습니다."),
+    FAVORITE_ALREADY_EXISTS(HttpStatus.CONFLICT, "FAVORITE-002", "해당 즐겨찾기는 이미 존재 합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/service/src/main/java/com/its/service/config/MongoConfig.java
+++ b/service/src/main/java/com/its/service/config/MongoConfig.java
@@ -1,0 +1,9 @@
+package com.its.service.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+
+@Configuration
+@EnableMongoAuditing
+public class MongoConfig {
+}

--- a/service/src/main/java/com/its/service/config/SwaggerConfig.java
+++ b/service/src/main/java/com/its/service/config/SwaggerConfig.java
@@ -70,7 +70,7 @@ public class SwaggerConfig {
         return new Info()
                 .title("ITS Server API") // API의 제목
                 .description("MVP API 명세서") // API에 대한 설명
-                .version("0.1.1"); // API의 버전
+                .version("0.1.2"); // API의 버전
     }
 }
 

--- a/service/src/main/java/com/its/service/domain/feat/favorite/controller/FavoriteController.java
+++ b/service/src/main/java/com/its/service/domain/feat/favorite/controller/FavoriteController.java
@@ -1,0 +1,64 @@
+package com.its.service.domain.feat.favorite.controller;
+
+import com.its.service.common.response.SuccessResponse;
+import com.its.service.common.response.factory.ResponseFactory;
+import com.its.service.domain.auth.security.oauth2.dto.oauth2.CustomOAuth2User;
+import com.its.service.domain.feat.favorite.dto.response.FavoriteResponse;
+import com.its.service.domain.feat.favorite.dto.response.FavoriteResponses;
+import com.its.service.domain.feat.favorite.service.FavoriteCommandService;
+import com.its.service.domain.feat.favorite.service.FavoriteQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/favorites")
+@RequiredArgsConstructor
+@Tag(name = "즐겨찾기", description = "Favorite API")
+public class FavoriteController {
+    private final FavoriteCommandService favoriteCommandService;
+    private final FavoriteQueryService favoriteQueryService;
+
+    @Operation(summary = "✅ [사용자] 즐겨찾기 등록", description = "특정 문제를 즐겨찾기에 추가하는 API")
+    @PostMapping("/{questionId}")
+    public ResponseEntity<SuccessResponse<Void>> addFavorite(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @PathVariable String questionId) {
+
+        Long userId = customOAuth2User.getUserId();
+        var result = favoriteCommandService.addFavorite(userId, questionId);
+        return ResponseFactory.success(result);
+    }
+
+    @Operation(summary = "✅ [사용자] 즐겨찾기 해제", description = "특정 문제를 즐겨찾기에서 제거하는 API")
+    @DeleteMapping("/{questionId}")
+    public ResponseEntity<SuccessResponse<Void>> removeFavorite(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @PathVariable String questionId) {
+
+        Long userId = customOAuth2User.getUserId();
+        var result = favoriteCommandService.removeFavorite(userId, questionId);
+        return ResponseFactory.success(result);
+    }
+
+    @Operation(summary = "✅ [사용자] 즐겨찾기 목록 조회", description = "사용자의 즐겨찾기 목록을 조회하는 API")
+    @GetMapping
+    public ResponseEntity<SuccessResponse<FavoriteResponses>> getFavorites(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+
+        Long userId = customOAuth2User.getUserId();
+        var result = favoriteQueryService.getFavorites(userId);
+        return ResponseFactory.success(result);
+    }
+
+    @Operation(summary = "✅ [사용자] 가장 최근에 추가한 즐겨찾기 조회", description = "사용자가 가장 최근에 추가한 즐겨찾기를 조회하는 API")
+    @GetMapping("/latest")
+    public ResponseEntity<SuccessResponse<FavoriteResponse>> getLatestFavorite(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+
+        Long userId = customOAuth2User.getUserId();
+        var result = favoriteQueryService.getLatestFavorite(userId);
+        return ResponseFactory.success(result);
+    }
+}

--- a/service/src/main/java/com/its/service/domain/feat/favorite/dto/response/FavoriteResponse.java
+++ b/service/src/main/java/com/its/service/domain/feat/favorite/dto/response/FavoriteResponse.java
@@ -1,0 +1,13 @@
+package com.its.service.domain.feat.favorite.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Schema(description = "즐겨찾기 응답 DTO")
+@Builder
+public record FavoriteResponse(
+        @Schema(description = "즐겨찾기 문제") String questionId
+)
+{}

--- a/service/src/main/java/com/its/service/domain/feat/favorite/dto/response/FavoriteResponses.java
+++ b/service/src/main/java/com/its/service/domain/feat/favorite/dto/response/FavoriteResponses.java
@@ -1,0 +1,13 @@
+package com.its.service.domain.feat.favorite.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Schema(description = "즐겨찾기 응답 DTO")
+@Builder
+public record FavoriteResponses(
+        @Schema(description = "즐겨찾기 문제 목록") List<String> favoriteQuestionIds
+)
+{}

--- a/service/src/main/java/com/its/service/domain/feat/favorite/entity/Favorite.java
+++ b/service/src/main/java/com/its/service/domain/feat/favorite/entity/Favorite.java
@@ -1,0 +1,29 @@
+package com.its.service.domain.feat.favorite.entity;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Document(collection = "favorites")
+public class Favorite {
+    @Id
+    private String favoriteId;
+
+    private Long userId;       // MySQL의 User ID
+    private String questionId; // MongoDB의 Question ID
+
+    @CreatedDate
+    private Instant createAt;
+
+    @LastModifiedDate
+    private Instant updateAt;
+}

--- a/service/src/main/java/com/its/service/domain/feat/favorite/mapper/FavoriteMapper.java
+++ b/service/src/main/java/com/its/service/domain/feat/favorite/mapper/FavoriteMapper.java
@@ -1,0 +1,40 @@
+package com.its.service.domain.feat.favorite.mapper;
+
+import com.its.service.domain.feat.favorite.dto.response.FavoriteResponse;
+import com.its.service.domain.feat.favorite.dto.response.FavoriteResponses;
+import com.its.service.domain.feat.favorite.entity.Favorite;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface FavoriteMapper {
+
+    @Mapping(target = "favoriteId", ignore = true) // ID는 MongoDB에서 자동 생성되므로 무시
+    @Mapping(target = "createAt", ignore = true) // 생성 시 자동 설정
+    @Mapping(target = "updateAt", ignore = true) // 수정 시 자동 설정
+    Favorite toEntity(Long userId, String questionId);
+
+    default List<String> toQuestionIdList(List<Favorite> favorites){
+        return favorites.stream().map(Favorite::getQuestionId).toList();
+    }
+
+    // 단일 Favorite을 FavoriteResponse로 변환
+    default FavoriteResponse toResponse(Favorite favorite) {
+        return FavoriteResponse.builder()
+                .questionId(favorite.getQuestionId())
+                .build();
+    }
+
+    // Favorite 리스트를 FavoriteResponses로 변환
+    default FavoriteResponses toResponses(List<Favorite> favorites) {
+        List<String> favoriteQuestionIds = favorites.stream()
+                .map(Favorite::getQuestionId)
+                .toList();
+
+        return FavoriteResponses.builder()
+                .favoriteQuestionIds(favoriteQuestionIds)
+                .build();
+    }
+}

--- a/service/src/main/java/com/its/service/domain/feat/favorite/repository/FavoriteRepository.java
+++ b/service/src/main/java/com/its/service/domain/feat/favorite/repository/FavoriteRepository.java
@@ -1,0 +1,16 @@
+package com.its.service.domain.feat.favorite.repository;
+
+import com.its.service.domain.feat.favorite.entity.Favorite;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FavoriteRepository extends MongoRepository<Favorite, String> {
+    Optional<Favorite> findByUserIdAndQuestionId(Long userId, String questionId);
+    List<Favorite> findAllByUserId(Long userId);
+    Optional<Favorite> findTopByUserIdOrderByCreateAtDesc(Long userId);
+    void deleteByUserIdAndQuestionId(Long userId, String questionId);
+    void deleteAllByUserId(Long userId);
+    boolean existsByUserIdAndQuestionId(Long userId, String questionId);
+}

--- a/service/src/main/java/com/its/service/domain/feat/favorite/service/FavoriteCommandService.java
+++ b/service/src/main/java/com/its/service/domain/feat/favorite/service/FavoriteCommandService.java
@@ -20,7 +20,7 @@ public class FavoriteCommandService {
     private final FavoriteMapper favoriteMapper;
 
     public Void addFavorite(Long userId, String questionId) {
-        userQueryService.getUserById(userId);
+        userQueryService.findUserById(userId);
         questionQueryService.getQuestionById(questionId);
         boolean isValid = favoriteQueryService.existByUserIAndQuestionId(userId, questionId);
         if (isValid) {
@@ -32,7 +32,7 @@ public class FavoriteCommandService {
     }
 
     public Void removeFavorite(Long userId, String questionId) {
-        userQueryService.getUserById(userId);
+        userQueryService.findUserById(userId);
         questionQueryService.getQuestionById(questionId);
         boolean isValid = favoriteQueryService.existByUserIAndQuestionId(userId, questionId);
         if (isValid) {

--- a/service/src/main/java/com/its/service/domain/feat/favorite/service/FavoriteCommandService.java
+++ b/service/src/main/java/com/its/service/domain/feat/favorite/service/FavoriteCommandService.java
@@ -1,0 +1,45 @@
+package com.its.service.domain.feat.favorite.service;
+
+import com.its.service.common.error.code.FavoriteErrorCode;
+import com.its.service.common.error.exception.CustomException;
+import com.its.service.domain.feat.favorite.entity.Favorite;
+import com.its.service.domain.feat.favorite.mapper.FavoriteMapper;
+import com.its.service.domain.feat.favorite.repository.FavoriteRepository;
+import com.its.service.domain.question.service.question.QuestionQueryService;
+import com.its.service.domain.user.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteCommandService {
+    private final FavoriteRepository favoriteRepository;
+    private final UserQueryService userQueryService;
+    private final QuestionQueryService questionQueryService;
+    private final FavoriteQueryService favoriteQueryService;
+    private final FavoriteMapper favoriteMapper;
+
+    public Void addFavorite(Long userId, String questionId) {
+        userQueryService.getUserById(userId);
+        questionQueryService.getQuestionById(questionId);
+        boolean isValid = favoriteQueryService.existByUserIAndQuestionId(userId, questionId);
+        if (isValid) {
+            throw new CustomException(FavoriteErrorCode.FAVORITE_ALREADY_EXISTS);
+        }
+        Favorite entity = favoriteMapper.toEntity(userId, questionId);
+        favoriteRepository.save(entity);
+        return null;
+    }
+
+    public Void removeFavorite(Long userId, String questionId) {
+        userQueryService.getUserById(userId);
+        questionQueryService.getQuestionById(questionId);
+        boolean isValid = favoriteQueryService.existByUserIAndQuestionId(userId, questionId);
+        if (isValid) {
+            throw new CustomException(FavoriteErrorCode.FAVORITE_ALREADY_EXISTS);
+        }
+        favoriteRepository.deleteByUserIdAndQuestionId(userId, questionId);
+        return null;
+    }
+
+}

--- a/service/src/main/java/com/its/service/domain/feat/favorite/service/FavoriteQueryService.java
+++ b/service/src/main/java/com/its/service/domain/feat/favorite/service/FavoriteQueryService.java
@@ -1,0 +1,50 @@
+package com.its.service.domain.feat.favorite.service;
+
+import com.its.service.common.error.code.FavoriteErrorCode;
+import com.its.service.common.error.exception.CustomException;
+import com.its.service.domain.feat.favorite.dto.response.FavoriteResponse;
+import com.its.service.domain.feat.favorite.dto.response.FavoriteResponses;
+import com.its.service.domain.feat.favorite.entity.Favorite;
+import com.its.service.domain.feat.favorite.mapper.FavoriteMapper;
+import com.its.service.domain.feat.favorite.repository.FavoriteRepository;
+import com.its.service.domain.user.service.UserQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteQueryService {
+    private final FavoriteRepository favoriteRepository;
+    private final FavoriteMapper favoriteMapper;
+    private final UserQueryService userQueryService;
+
+    public FavoriteResponse getLatestFavorite(Long userId) {
+        userQueryService.getUserById(userId);
+        Favorite favorite = favoriteRepository.findTopByUserIdOrderByCreateAtDesc(userId).orElseThrow(() -> new CustomException(FavoriteErrorCode.FAVORITE_NOT_FOUND));
+        return favoriteMapper.toResponse(favorite);
+    }
+
+    public FavoriteResponse getFavorite(Long userId, String questionId) {
+        userQueryService.getUserById(userId);
+        Favorite favorite = findFavoriteByUserIAndQuestionId(userId, questionId);
+        return favoriteMapper.toResponse(favorite);
+    }
+
+    public FavoriteResponses getFavorites(Long userId) {
+        userQueryService.getUserById(userId);
+        List<Favorite> favorites = favoriteRepository.findAllByUserId(userId);
+        return favoriteMapper.toResponses(favorites);
+    }
+
+    public Favorite findFavoriteByUserIAndQuestionId(Long userId, String questionId) {
+        return favoriteRepository.findByUserIdAndQuestionId(userId, questionId).orElseThrow(() -> new CustomException(FavoriteErrorCode.FAVORITE_NOT_FOUND));
+    }
+
+    public boolean existByUserIAndQuestionId(Long userId, String questionId) {
+        return favoriteRepository.existsByUserIdAndQuestionId(userId, questionId);
+    }
+}

--- a/service/src/main/java/com/its/service/domain/feat/favorite/service/FavoriteQueryService.java
+++ b/service/src/main/java/com/its/service/domain/feat/favorite/service/FavoriteQueryService.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 
 @Service
@@ -23,19 +22,19 @@ public class FavoriteQueryService {
     private final UserQueryService userQueryService;
 
     public FavoriteResponse getLatestFavorite(Long userId) {
-        userQueryService.getUserById(userId);
+        userQueryService.findUserById(userId);
         Favorite favorite = favoriteRepository.findTopByUserIdOrderByCreateAtDesc(userId).orElseThrow(() -> new CustomException(FavoriteErrorCode.FAVORITE_NOT_FOUND));
         return favoriteMapper.toResponse(favorite);
     }
 
     public FavoriteResponse getFavorite(Long userId, String questionId) {
-        userQueryService.getUserById(userId);
+        userQueryService.findUserById(userId);
         Favorite favorite = findFavoriteByUserIAndQuestionId(userId, questionId);
         return favoriteMapper.toResponse(favorite);
     }
 
     public FavoriteResponses getFavorites(Long userId) {
-        userQueryService.getUserById(userId);
+        userQueryService.findUserById(userId);
         List<Favorite> favorites = favoriteRepository.findAllByUserId(userId);
         return favoriteMapper.toResponses(favorites);
     }

--- a/service/src/main/java/com/its/service/domain/question/service/choice/ChoiceQueryService.java
+++ b/service/src/main/java/com/its/service/domain/question/service/choice/ChoiceQueryService.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-
 @Service
 @Slf4j
 @RequiredArgsConstructor

--- a/service/src/main/java/com/its/service/domain/question/service/explanation/ExplanationQueryService.java
+++ b/service/src/main/java/com/its/service/domain/question/service/explanation/ExplanationQueryService.java
@@ -1,11 +1,8 @@
 package com.its.service.domain.question.service.explanation;
 
-import com.its.service.common.error.code.QuestionErrorCode;
-import com.its.service.common.error.exception.CustomException;
 import com.its.service.domain.question.dto.response.ExplanationResponse;
 import com.its.service.domain.question.entity.Question;
 import com.its.service.domain.question.mapper.ExplanationMapper;
-import com.its.service.domain.question.repository.QuestionRepository;
 import com.its.service.domain.question.service.question.QuestionQueryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/service/src/main/java/com/its/service/domain/question/service/question/QuestionQueryService.java
+++ b/service/src/main/java/com/its/service/domain/question/service/question/QuestionQueryService.java
@@ -1,11 +1,8 @@
 package com.its.service.domain.question.service.question;
 
-import com.its.service.common.error.code.MinorErrorCode;
 import com.its.service.common.error.code.QuestionErrorCode;
-import com.its.service.common.error.code.SubjectErrorCode;
 import com.its.service.common.error.exception.CustomException;
 import com.its.service.domain.classification.entity.Minor;
-import com.its.service.domain.classification.repository.MinorRepository;
 import com.its.service.domain.classification.service.ClassificationQueryService;
 import com.its.service.domain.question.dto.response.QuestionResponse;
 import com.its.service.domain.question.dto.response.QuestionResponses;
@@ -13,7 +10,6 @@ import com.its.service.domain.question.entity.Question;
 import com.its.service.domain.question.mapper.QuestionMapper;
 import com.its.service.domain.question.repository.QuestionRepository;
 import com.its.service.domain.subject.entity.Subject;
-import com.its.service.domain.subject.repository.SubjectRepository;
 import com.its.service.domain.subject.service.SubjectQueryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/service/src/main/java/com/its/service/domain/user/service/UserQueryService.java
+++ b/service/src/main/java/com/its/service/domain/user/service/UserQueryService.java
@@ -26,4 +26,9 @@ public class UserQueryService {
 
         return userMapper.toInfoResponse(user);
     }
+
+    public User findUserById(Long id) {
+        return userRepository.findById(id).orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+    }
+
 }


### PR DESCRIPTION
# API version 0.1.2

## 주요 변경사항 
- 즐겨찾기 기능 추가 

### 신규 API: 
- [POST] `/api/favorites/{questionId}` [사용자] 즐겨찾기 등록
- [DELETE] `/api/favorites/{questionId}`  [사용자] 즐겨찾기 해제
- [GET] `/api/favorites` [사용자] 즐겨찾기 목록 조회
- [GET] `/api/favorites/latest` [사용자] 가장 최근에 추가한 즐겨찾기 조회
